### PR TITLE
Day 05 - Add Pydantic Validation, Create Dummy Data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "faker>=37.4.2",
     "poethepoet>=0.36.0",
     "pytest>=8.4.1",
     "pytest-cov>=6.2.1",
@@ -28,3 +29,7 @@ lint = "uv tool run ruff check ."
 format = "uv tool run ruff format ."
 tc = "uv tool run ty check ."
 apirun = "uv run fastapi dev src/main.py"
+
+[tool.poe.tasks.dummy]
+cmd = "uv run scripts/generate_dummy_data.py"
+env = { PYTHONPATH = "." }

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+# pytest.ini
+[pytest]
+markers =
+    focus: Mark a test to be focused on for execution.

--- a/scripts/generate_dummy_data.py
+++ b/scripts/generate_dummy_data.py
@@ -1,0 +1,96 @@
+import random
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
+from pathlib import Path
+
+from faker import Faker
+from sqlmodel import Session, create_engine
+
+from src.models import Category, SQLModel, Transaction
+
+fake = Faker()
+random.seed(42)
+Faker.seed(42)
+
+CSV_DIR = Path("scripts/generated_data")
+CSV_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def random_date_within_last_year() -> date:
+    days_ago = random.randint(0, 365)
+    return (datetime.now(timezone.utc) - timedelta(days=days_ago)).date()
+
+
+def generate_categories() -> list[Category]:
+    category_names = [
+        "Groceries",
+        "Rent",
+        "Utilities",
+        "Restaurant",
+        "Business Miscallaneous",
+        "General Merchandise",
+        "Insurance",
+        "Gas/Fuel",
+        "Automotive",
+        "Subscriptions",
+    ]
+    categories = []
+    for name in category_names:
+        budget = round(random.uniform(50, 2000), 2)
+        categories.append(Category(name=name, budget=Decimal(budget)))
+    return categories
+
+
+def generate_transactions(categories: list[Category], n=250) -> list[Transaction]:
+    transactions = []
+    for _ in range(n):
+        amount = round(random.uniform(5, 300), 2)
+        trans = Transaction(
+            trans_date=random_date_within_last_year(),
+            amount=Decimal(amount),
+            vendor=fake.company()[:25],
+            note=fake.sentence(nb_words=6)[:50],
+            category_id=random.choice(categories).id if categories else None,
+        )
+        transactions.append(trans)
+    return transactions
+
+
+def get_engine():
+    engine = create_engine("sqlite:///finance_tracker.sqlite", echo=False)
+    return engine
+
+
+def create_db_and_tables(engine):
+    SQLModel.metadata.drop_all(engine)
+    SQLModel.metadata.create_all(engine)
+
+
+def generate_data(engine):
+    with Session(engine) as session:
+        categories = generate_categories()
+        for cat in categories:
+            session.add(cat)
+        session.commit()
+
+        for cat in categories:
+            session.refresh(cat)
+
+        transactions = generate_transactions(categories)
+        for t in transactions:
+            session.add(t)
+        session.commit()
+
+        print(
+            f"Generated {len(categories)} categories and {len(transactions)} transactions"
+        )
+
+
+def main():
+    engine = get_engine()
+    create_db_and_tables(engine)
+    generate_data(engine)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_dummy_data.py
+++ b/scripts/generate_dummy_data.py
@@ -1,7 +1,6 @@
 import random
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
-from pathlib import Path
 
 from faker import Faker
 from sqlmodel import Session, create_engine
@@ -11,9 +10,6 @@ from src.models import Category, SQLModel, Transaction
 fake = Faker()
 random.seed(42)
 Faker.seed(42)
-
-CSV_DIR = Path("scripts/generated_data")
-CSV_DIR.mkdir(parents=True, exist_ok=True)
 
 
 def random_date_within_last_year() -> date:

--- a/src/models.py
+++ b/src/models.py
@@ -1,7 +1,8 @@
+import re
 from datetime import date, datetime, timezone
 from decimal import Decimal
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 from sqlmodel import Field, Relationship, SQLModel
 
 
@@ -14,6 +15,13 @@ class MySQLModel(SQLModel):
 class CategoryBase(MySQLModel):
     name: str = Field(min_length=3, max_length=25)
     budget: Decimal | None = Field(max_digits=10, decimal_places=2, default=None)
+
+    @field_validator("name", mode="before")
+    @classmethod
+    def standardize_name(cls, value: str) -> str:
+        value = re.sub(r"\s+", " ", value)
+        value = value.title()
+        return value
 
 
 class Category(CategoryBase, table=True):
@@ -30,10 +38,17 @@ class CategoryUpdate(MySQLModel):
     name: str | None = Field(min_length=3, max_length=25, default=None)
     budget: Decimal | None = Field(max_digits=10, decimal_places=2, default=None)
 
+    @field_validator("name", mode="before")
+    @classmethod
+    def standardize_name(cls, value: str) -> str:
+        value = re.sub(r"\s+", " ", value)
+        value = value.title()
+        return value
+
 
 class CategoryRead(CategoryBase):
     id: int
-    budget: Decimal = Field(max_digits=10, decimal_places=2)
+    budget: Decimal | None = Field(max_digits=10, decimal_places=2)
 
 
 class CategoryReadNested(MySQLModel):

--- a/src/models.py
+++ b/src/models.py
@@ -12,9 +12,15 @@ class MySQLModel(SQLModel):
     )
 
 
+field_money_dec_or_none = Field(max_digits=10, decimal_places=2, default=None)
+field_money_dec = Field(max_digits=10, decimal_places=2)
+field_str_1_25_or_none = Field(min_length=1, max_length=25, default=None)
+field_str_1_25 = Field(min_length=1, max_length=25)
+
+
 class CategoryBase(MySQLModel):
-    name: str = Field(min_length=3, max_length=25)
-    budget: Decimal | None = Field(max_digits=10, decimal_places=2, default=None)
+    name: str = field_str_1_25
+    budget: Decimal | None = field_money_dec_or_none
 
     @field_validator("name", mode="before")
     @classmethod
@@ -34,21 +40,12 @@ class CategoryCreate(CategoryBase):
     pass
 
 
-class CategoryUpdate(MySQLModel):
-    name: str | None = Field(min_length=3, max_length=25, default=None)
-    budget: Decimal | None = Field(max_digits=10, decimal_places=2, default=None)
-
-    @field_validator("name", mode="before")
-    @classmethod
-    def standardize_name(cls, value: str) -> str:
-        value = re.sub(r"\s+", " ", value)
-        value = value.title()
-        return value
+class CategoryUpdate(CategoryBase):
+    name: str | None = field_str_1_25_or_none
 
 
 class CategoryRead(CategoryBase):
     id: int
-    budget: Decimal | None = Field(max_digits=10, decimal_places=2)
 
 
 class CategoryReadNested(MySQLModel):
@@ -58,8 +55,8 @@ class CategoryReadNested(MySQLModel):
 
 class TransactionBase(MySQLModel):
     trans_date: date
-    amount: Decimal = Field(max_digits=10, decimal_places=2)
-    vendor: str = Field(min_length=3, max_length=25)
+    amount: Decimal = field_money_dec
+    vendor: str = field_str_1_25
     note: str | None = Field(min_length=1, max_length=50, default=None)
 
 
@@ -83,11 +80,11 @@ class TransactionCreate(TransactionBase):
     category_id: int | None = None
 
 
-class TransactionUpdate(MySQLModel):
+class TransactionUpdate(TransactionBase):
     trans_date: datetime | None = None
-    amount: Decimal | None = Field(max_digits=10, decimal_places=2, default=None)
-    vendor: str | None = Field(min_length=3, max_length=25, default=None)
-    note: str | None = Field(min_length=1, max_length=25, default=None)
+    amount: Decimal | None = field_money_dec_or_none
+    vendor: str | None = field_str_1_25_or_none
+
     category_id: int | None = None
 
 

--- a/src/models.py
+++ b/src/models.py
@@ -1,13 +1,19 @@
 from datetime import date, datetime, timezone
 from decimal import Decimal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from sqlmodel import Column, Field, Numeric, Relationship, SQLModel
 
 
-class CategoryBase(SQLModel):
-    name: str
-    budget: Decimal | None = Field(sa_column=Column(Numeric(10, 2)))
+class MySQLModel(SQLModel):
+    model_config = ConfigDict(
+        str_strip_whitespace=True,
+    )
+
+
+class CategoryBase(MySQLModel):
+    name: str = Field(min_length=3, max_length=25)
+    budget: Decimal | None = Field(sa_column=Column(Numeric(10, 2)), default=None)
 
 
 class Category(CategoryBase, table=True):
@@ -20,8 +26,8 @@ class CategoryCreate(CategoryBase):
     pass
 
 
-class CategoryUpdate(SQLModel):
-    name: str | None = None
+class CategoryUpdate(MySQLModel):
+    name: str | None = Field(min_length=3, max_length=25, default=None)
     budget: Decimal | None = None
 
 
@@ -29,16 +35,16 @@ class CategoryRead(CategoryBase):
     id: int
 
 
-class CategoryReadNested(SQLModel):
+class CategoryReadNested(MySQLModel):
     id: int
     name: str
 
 
-class TransactionBase(SQLModel):
+class TransactionBase(MySQLModel):
     trans_date: date
     amount: Decimal = Field(sa_column=Column(Numeric(10, 2)))
-    vendor: str
-    note: str | None = None
+    vendor: str = Field(min_length=3, max_length=25)
+    note: str | None = Field(min_length=1, max_length=50, default=None)
 
 
 class Transaction(TransactionBase, table=True):
@@ -61,11 +67,11 @@ class TransactionCreate(TransactionBase):
     category_id: int | None = None
 
 
-class TransactionUpdate(SQLModel):
+class TransactionUpdate(MySQLModel):
     trans_date: datetime | None = None
     amount: Decimal | None = None
-    vendor: str | None = None
-    note: str | None = None
+    vendor: str | None = Field(min_length=3, max_length=25, default=None)
+    note: str | None = Field(min_length=1, max_length=25, default=None)
     category_id: int | None = None
 
 

--- a/src/models.py
+++ b/src/models.py
@@ -2,7 +2,7 @@ from datetime import date, datetime, timezone
 from decimal import Decimal
 
 from pydantic import BaseModel, ConfigDict
-from sqlmodel import Column, Field, Numeric, Relationship, SQLModel
+from sqlmodel import Field, Relationship, SQLModel
 
 
 class MySQLModel(SQLModel):
@@ -13,7 +13,7 @@ class MySQLModel(SQLModel):
 
 class CategoryBase(MySQLModel):
     name: str = Field(min_length=3, max_length=25)
-    budget: Decimal | None = Field(sa_column=Column(Numeric(10, 2)), default=None)
+    budget: Decimal | None = Field(max_digits=10, decimal_places=2, default=None)
 
 
 class Category(CategoryBase, table=True):
@@ -28,11 +28,12 @@ class CategoryCreate(CategoryBase):
 
 class CategoryUpdate(MySQLModel):
     name: str | None = Field(min_length=3, max_length=25, default=None)
-    budget: Decimal | None = None
+    budget: Decimal | None = Field(max_digits=10, decimal_places=2, default=None)
 
 
 class CategoryRead(CategoryBase):
     id: int
+    budget: Decimal = Field(max_digits=10, decimal_places=2)
 
 
 class CategoryReadNested(MySQLModel):
@@ -42,7 +43,7 @@ class CategoryReadNested(MySQLModel):
 
 class TransactionBase(MySQLModel):
     trans_date: date
-    amount: Decimal = Field(sa_column=Column(Numeric(10, 2)))
+    amount: Decimal = Field(max_digits=10, decimal_places=2)
     vendor: str = Field(min_length=3, max_length=25)
     note: str | None = Field(min_length=1, max_length=50, default=None)
 
@@ -69,7 +70,7 @@ class TransactionCreate(TransactionBase):
 
 class TransactionUpdate(MySQLModel):
     trans_date: datetime | None = None
-    amount: Decimal | None = None
+    amount: Decimal | None = Field(max_digits=10, decimal_places=2, default=None)
     vendor: str | None = Field(min_length=3, max_length=25, default=None)
     note: str | None = Field(min_length=1, max_length=25, default=None)
     category_id: int | None = None

--- a/tests/test_api_categories.py
+++ b/tests/test_api_categories.py
@@ -32,6 +32,20 @@ def test_create_category(client: TestClient, add_category):
     assert data["budget"] == "200.00"
 
 
+def test_create_category_standardize_name(client: TestClient):
+    payload = {
+        "name": "   food  and drINK  ",
+        "budget": None,
+    }
+    response = client.post("/categories", json=payload)
+    data = response.json()
+
+    assert response.status_code == 201
+    assert data["id"] == 1
+    assert data["name"] == "Food And Drink"
+    assert data["budget"] is None
+
+
 def test_create_category_422_empty_payload(client: TestClient):
     payload = {}
     response = client.post("/categories", json=payload)
@@ -141,6 +155,20 @@ def test_update_category_conflicting_name(
     response = client.patch("/categories/2", json=payload)
     assert response.status_code == 409
     assert "already exists" in response.json()["detail"]
+
+
+def test_update_category_standardize_name(client: TestClient, add_category):
+    payload = {
+        "name": "   food  and drINK  ",
+        "budget": None,
+    }
+    response = client.patch("/categories/1", json=payload)
+    data = response.json()
+
+    assert response.status_code == 200
+    assert data["id"] == 1
+    assert data["name"] == "Food And Drink"
+    assert data["budget"] is None
 
 
 def test_update_category_not_found(client: TestClient):

--- a/tests/test_api_categories.py
+++ b/tests/test_api_categories.py
@@ -65,7 +65,7 @@ def test_create_or_update_category_422_bad_strings(
     assert response.status_code == 422
     assert data["detail"][0]["type"] == "string_too_short"
 
-    payload = {"name": "  t    "}
+    payload = {"name": " " * 5}
     response = client.request(method, url, json=payload)
     data = response.json()
     assert response.status_code == 422

--- a/tests/test_api_categories.py
+++ b/tests/test_api_categories.py
@@ -171,6 +171,22 @@ def test_update_category_standardize_name(client: TestClient, add_category):
     assert data["budget"] is None
 
 
+@pytest.mark.focus()
+def test_update_category_update_budget(client: TestClient, add_category):
+    """Test existing category can update budget without aggressive validation."""
+    payload = {
+        "name": "Utilities",
+        "budget": 100.00,
+    }
+    response = client.patch("/categories/1", json=payload)
+    data = response.json()
+
+    assert response.status_code == 200
+    assert data["id"] == 1
+    assert data["name"] == "Utilities"
+    assert data["budget"] == "100.00"
+
+
 def test_update_category_not_found(client: TestClient):
     response = client.patch("/categories/99", json={})
     data = response.json()

--- a/tests/test_api_transactions.py
+++ b/tests/test_api_transactions.py
@@ -109,8 +109,8 @@ def test_create_or_update_transaction_422_bad_strings(
     payload = {
         "trans_date": "2024-07-14",
         "amount": 54.99,
-        "vendor": "  t    ",
-        "note": "       ",
+        "vendor": " " * 5,
+        "note": " " * 5,
     }
     response = client.request(method, url, json=payload)
     data = response.json()

--- a/tests/test_api_transactions.py
+++ b/tests/test_api_transactions.py
@@ -131,6 +131,43 @@ def test_create_or_update_transaction_422_bad_strings(
     assert data["detail"][1]["type"] == "string_too_long"
 
 
+@pytest.mark.parametrize(
+    "method,url", [("POST", "/transactions"), ("PATCH", "/transactions/1")]
+)
+def test_create_or_update_transaction_422_bad_amount(
+    client: TestClient, add_transaction, method, url
+):
+    payload = {
+        "trans_date": "2024-07-14",
+        "amount": 1 * 10**9,
+        "vendor": "AT&T",
+    }
+    response = client.request(method, url, json=payload)
+    data = response.json()
+    assert response.status_code == 422
+    assert data["detail"][0]["type"] == "decimal_whole_digits"
+
+    payload = {
+        "trans_date": "2024-07-14",
+        "amount": 1 * 10**11,
+        "vendor": "AT&T",
+    }
+    response = client.request(method, url, json=payload)
+    data = response.json()
+    assert response.status_code == 422
+    assert data["detail"][0]["type"] == "decimal_max_digits"
+
+    payload = {
+        "trans_date": "2024-07-14",
+        "amount": 1.001,
+        "vendor": "AT&T",
+    }
+    response = client.request(method, url, json=payload)
+    data = response.json()
+    assert response.status_code == 422
+    assert data["detail"][0]["type"] == "decimal_max_places"
+
+
 def test_get_transactions(client: TestClient, add_transaction, add_another_transaction):
     response = client.get("/transactions")
     data = response.json()

--- a/uv.lock
+++ b/uv.lock
@@ -122,6 +122,18 @@ wheels = [
 ]
 
 [[package]]
+name = "faker"
+version = "37.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/95/da573e055608e180086e2ac3208f8c15d8b44220912f565a9821b9bff33a/faker-37.4.2.tar.gz", hash = "sha256:8e281bbaea30e5658895b8bea21cc50d27aaf3a43db3f2694409ca5701c56b0a", size = 1902890, upload_time = "2025-07-15T16:38:24.803Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/1c/b909a055be556c11f13cf058cfa0e152f9754d803ff3694a937efe300709/faker-37.4.2-py3-none-any.whl", hash = "sha256:b70ed1af57bfe988cbcd0afd95f4768c51eaf4e1ce8a30962e127ac5c139c93f", size = 1943179, upload_time = "2025-07-15T16:38:23.053Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.116.1"
 source = { registry = "https://pypi.org/simple" }
@@ -196,6 +208,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "faker" },
     { name = "poethepoet" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -211,6 +224,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "faker", specifier = ">=37.4.2" },
     { name = "poethepoet", specifier = ">=0.36.0" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
@@ -724,6 +738,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28", size = 75726, upload_time = "2025-05-21T18:55:23.885Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51", size = 14552, upload_time = "2025-05-21T18:55:22.152Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380, upload_time = "2025-03-23T13:54:43.652Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839, upload_time = "2025-03-23T13:54:41.845Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Change Log
- Add validation to SQLModel models (using Pydantic features)
  - String fields have max and min length
  - String fields have leading and trailing white space removed
  - Category name is standardized
  - Money fields are restricted to 2 decimal places
- Refactor SQLModel fields that are common among models
- Create script to generate dummy date using Faker. This is to have enough data for developing the pagination and search features.

## TODO
- [ ] Add feature to search transactions in API (to support reporting in frontend UI)
- [ ] Add pagination to GET transactions endpoint
- [ ]  Set up Postgres database in Docker to replace current SQLite database