### PR TITLE
Day 06 - Add Basic Search and Pagination to GET Transactions

### DIFF
--- a/scripts/generate_dummy_data.py
+++ b/scripts/generate_dummy_data.py
@@ -2,6 +2,7 @@ import random
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 
+from decouple import config
 from faker import Faker
 from sqlmodel import Session, create_engine
 
@@ -53,11 +54,12 @@ def generate_transactions(categories: list[Category], n=250) -> list[Transaction
 
 
 def get_engine():
-    engine = create_engine("sqlite:///finance_tracker.sqlite", echo=False)
+    DATABASE_URL = config("DATABASE_URL_DUMMY", "sqlite:///finance_tracker.sqlite")
+    engine = create_engine(DATABASE_URL, echo=False)
     return engine
 
 
-def create_db_and_tables(engine):
+def recreate_db_and_tables(engine):
     SQLModel.metadata.drop_all(engine)
     SQLModel.metadata.create_all(engine)
 
@@ -84,7 +86,7 @@ def generate_data(engine):
 
 def main():
     engine = get_engine()
-    create_db_and_tables(engine)
+    recreate_db_and_tables(engine)
     generate_data(engine)
 
 

--- a/scripts/generate_dummy_data.py
+++ b/scripts/generate_dummy_data.py
@@ -54,8 +54,11 @@ def generate_transactions(categories: list[Category], n=250) -> list[Transaction
 
 
 def get_engine():
-    DATABASE_URL = config("DATABASE_URL_DUMMY", "sqlite:///finance_tracker.sqlite")
-    engine = create_engine(DATABASE_URL, echo=False)
+    DATABASE_URL_DUMMY = config(
+        "DATABASE_URL_DUMMY", "sqlite:///finance_tracker.sqlite"
+    )
+    DEBUG = config("DEBUG", default=False, cast=bool)
+    engine = create_engine(DATABASE_URL_DUMMY, echo=DEBUG)
     return engine
 
 

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -7,8 +7,9 @@ from sqlmodel import Session, create_engine
 from .models import PaginationInput
 
 DATABASE_URL = config("DATABASE_URL")
+DEBUG = config("DEBUG", default=False, cast=bool)
 connect_args = {"check_same_thread": False}
-engine = create_engine(DATABASE_URL, connect_args=connect_args)
+engine = create_engine(DATABASE_URL, connect_args=connect_args, echo=DEBUG)
 
 
 def get_session():

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -4,6 +4,8 @@ from decouple import config
 from fastapi import Depends
 from sqlmodel import Session, create_engine
 
+from .models import PaginationInput
+
 DATABASE_URL = config("DATABASE_URL")
 connect_args = {"check_same_thread": False}
 engine = create_engine(DATABASE_URL, connect_args=connect_args)
@@ -15,3 +17,5 @@ def get_session():
 
 
 SessionDep = Annotated[Session, Depends(get_session)]
+
+PaginationDep = Annotated[PaginationInput, Depends()]

--- a/src/models.py
+++ b/src/models.py
@@ -12,15 +12,15 @@ class MySQLModel(SQLModel):
     )
 
 
-field_money_dec_or_none = Field(max_digits=10, decimal_places=2, default=None)
-field_money_dec = Field(max_digits=10, decimal_places=2)
-field_str_1_25_or_none = Field(min_length=1, max_length=25, default=None)
-field_str_1_25 = Field(min_length=1, max_length=25)
+MoneyFieldOrNone = Field(max_digits=10, decimal_places=2, default=None)
+MoneyField = Field(max_digits=10, decimal_places=2)
+StringFieldOrNone = Field(min_length=1, max_length=25, default=None)
+StringField = Field(min_length=1, max_length=25)
 
 
 class CategoryBase(MySQLModel):
-    name: str = field_str_1_25
-    budget: Decimal | None = field_money_dec_or_none
+    name: str = StringField
+    budget: Decimal | None = MoneyFieldOrNone
 
     @field_validator("name", mode="before")
     @classmethod
@@ -41,7 +41,7 @@ class CategoryCreate(CategoryBase):
 
 
 class CategoryUpdate(CategoryBase):
-    name: str | None = field_str_1_25_or_none
+    name: str | None = StringFieldOrNone
 
 
 class CategoryRead(CategoryBase):
@@ -55,8 +55,8 @@ class CategoryReadNested(MySQLModel):
 
 class TransactionBase(MySQLModel):
     trans_date: date
-    amount: Decimal = field_money_dec
-    vendor: str = field_str_1_25
+    amount: Decimal = MoneyField
+    vendor: str = StringField
     note: str | None = Field(min_length=1, max_length=50, default=None)
 
 
@@ -82,8 +82,8 @@ class TransactionCreate(TransactionBase):
 
 class TransactionUpdate(TransactionBase):
     trans_date: datetime | None = None
-    amount: Decimal | None = field_money_dec_or_none
-    vendor: str | None = field_str_1_25_or_none
+    amount: Decimal | None = MoneyFieldOrNone
+    vendor: str | None = StringFieldOrNone
 
     category_id: int | None = None
 

--- a/src/models.py
+++ b/src/models.py
@@ -97,3 +97,8 @@ class TransactionRead(TransactionBase):
 
 class DeleteResponse(BaseModel):
     detail: str
+
+
+class PaginationInput(BaseModel):
+    page: int = Field(default=1, ge=1)
+    size: int = Field(default=25, ge=1, le=50)

--- a/src/routers/transactions.py
+++ b/src/routers/transactions.py
@@ -38,7 +38,13 @@ def create_transaction(transaction: TransactionCreate, session: SessionDep):
 
 @router.get("/", response_model=list[TransactionRead])
 def read_transactions(session: SessionDep):
-    transactions = session.exec(select(Transaction)).all()
+    query = select(Transaction).order_by(
+        Transaction.trans_date.desc(),
+        Transaction.vendor.desc(),
+        Transaction.amount.desc(),
+    )
+    transactions = session.exec(query).all()
+
     return transactions
 
 

--- a/src/routers/transactions.py
+++ b/src/routers/transactions.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, HTTPException, status
 from sqlmodel import select
 
-from ..dependencies import SessionDep
+from ..dependencies import PaginationDep, SessionDep
 from ..models import (
     Category,
     DeleteResponse,
@@ -37,11 +37,17 @@ def create_transaction(transaction: TransactionCreate, session: SessionDep):
 
 
 @router.get("/", response_model=list[TransactionRead])
-def read_transactions(session: SessionDep):
-    query = select(Transaction).order_by(
-        Transaction.trans_date.desc(),
-        Transaction.vendor.desc(),
-        Transaction.amount.desc(),
+def read_transactions(session: SessionDep, pagination_input: PaginationDep):
+    offset = (pagination_input.page - 1) * pagination_input.size
+    query = (
+        select(Transaction)
+        .order_by(
+            Transaction.trans_date.desc(),
+            Transaction.vendor.desc(),
+            Transaction.amount.desc(),
+        )
+        .offset(offset)
+        .limit(pagination_input.size)
     )
     transactions = session.exec(query).all()
 

--- a/tests/test_api_categories.py
+++ b/tests/test_api_categories.py
@@ -171,7 +171,6 @@ def test_update_category_standardize_name(client: TestClient, add_category):
     assert data["budget"] is None
 
 
-@pytest.mark.focus()
 def test_update_category_update_budget(client: TestClient, add_category):
     """Test existing category can update budget without aggressive validation."""
     payload = {

--- a/tests/test_api_categories.py
+++ b/tests/test_api_categories.py
@@ -56,26 +56,21 @@ def test_create_category_422_empty_payload(client: TestClient):
 @pytest.mark.parametrize(
     "method,url", [("POST", "/categories"), ("PATCH", "/categories/1")]
 )
+@pytest.mark.parametrize(
+    "payload,expected_error_type",
+    [
+        ({"name": ""}, "string_too_short"),
+        ({"name": " " * 5}, "string_too_short"),
+        ({"name": "x" * 50}, "string_too_long"),
+    ],
+)
 def test_create_or_update_category_422_bad_strings(
-    client: TestClient, add_category, method, url
+    client: TestClient, add_category, method, url, payload, expected_error_type
 ):
-    payload = {"name": ""}
     response = client.request(method, url, json=payload)
     data = response.json()
     assert response.status_code == 422
-    assert data["detail"][0]["type"] == "string_too_short"
-
-    payload = {"name": " " * 5}
-    response = client.request(method, url, json=payload)
-    data = response.json()
-    assert response.status_code == 422
-    assert data["detail"][0]["type"] == "string_too_short"
-
-    payload = {"name": "x" * 50}
-    response = client.request(method, url, json=payload)
-    data = response.json()
-    assert response.status_code == 422
-    assert data["detail"][0]["type"] == "string_too_long"
+    assert data["detail"][0]["type"] == expected_error_type
 
 
 @pytest.mark.parametrize(

--- a/tests/test_api_transactions.py
+++ b/tests/test_api_transactions.py
@@ -178,7 +178,7 @@ def test_get_transactions(client: TestClient, add_transaction, add_another_trans
     assert data[1]["trans_date"] == "2024-07-14"
 
 
-def test_get_transactions_search(
+def test_get_transactions_search_by_term(
     client: TestClient, add_transaction, add_another_transaction
 ):
     response = client.get("/transactions/?q=Utilities")

--- a/tests/test_api_transactions.py
+++ b/tests/test_api_transactions.py
@@ -174,6 +174,8 @@ def test_get_transactions(client: TestClient, add_transaction, add_another_trans
 
     assert response.status_code == 200
     assert len(data) == 2
+    assert data[0]["trans_date"] == "2025-11-02"
+    assert data[1]["trans_date"] == "2024-07-14"
 
 
 def test_get_transaction(client: TestClient, add_transaction):

--- a/tests/test_api_transactions.py
+++ b/tests/test_api_transactions.py
@@ -178,6 +178,25 @@ def test_get_transactions(client: TestClient, add_transaction, add_another_trans
     assert data[1]["trans_date"] == "2024-07-14"
 
 
+def test_get_transactions_search(
+    client: TestClient, add_transaction, add_another_transaction
+):
+    response = client.get("/transactions/?q=Utilities")
+    data = response.json()
+    assert response.status_code == 200
+    assert len(data) == 1
+
+    response = client.get("/transactions/?q=%20%20KrOgER%20")
+    data = response.json()
+    assert response.status_code == 200
+    assert len(data) == 1
+
+    response = client.get("/transactions/?q=DoesNotExist")
+    data = response.json()
+    assert response.status_code == 200
+    assert len(data) == 0
+
+
 def test_get_transaction(client: TestClient, add_transaction):
     response = client.get("/transactions/1")
     data = response.json()


### PR DESCRIPTION
## Change Log
- Enhance GET transaction route with search feature
  - Sort transactions returned
  - Add pagination using "page number" and "page size" pattern
  - Add ability to filter transactions by fields Vendor, Category, and Note
- Implement changes recommended in [PR#18](https://github.com/kishanpatel789/finance_tracker/pull/18) (branch `day05`)
  - Update dummy data script with environment variables and more accurate function names
  - Remove metadata from variable names of re-used Field objects
  - Further parametrize validation tests

## TODO
- [ ] Further enhance GET transaction route
  - [ ] Implement filter by date range (on transaction date)
  - [ ] Enhance pagination for edge cases (eg input page number is too high, etc)
- [ ]  Set up Postgres database in Docker to replace current SQLite database