### PR TITLE
Day 07 - Add Date Search GET Transactions, Add Metadata to GET Transactions

### DIFF
--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -4,8 +4,6 @@ from decouple import config
 from fastapi import Depends
 from sqlmodel import Session, create_engine
 
-from .models import PaginationInput
-
 DATABASE_URL = config("DATABASE_URL")
 DEBUG = config("DEBUG", default=False, cast=bool)
 connect_args = {"check_same_thread": False}
@@ -18,5 +16,3 @@ def get_session():
 
 
 SessionDep = Annotated[Session, Depends(get_session)]
-
-PaginationDep = Annotated[PaginationInput, Depends()]

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -1,5 +1,38 @@
 from urllib.parse import urlencode
 
+from fastapi import Request
+
+from .models import PageLinks
+
 
 def generate_url_query(query_map: dict) -> str:
     return urlencode({k: v for k, v in query_map.items() if v is not None})
+
+
+def generate_links(
+    current_page: int,
+    total_page_count: int,
+    request: Request,
+    query_map: dict,
+) -> PageLinks:
+    base_url = request.base_url
+
+    current = f"{base_url}?{generate_url_query(query_map)}"
+
+    if current_page > 1:
+        query_map.update(dict(page=current_page - 1))
+        prev = f"{base_url}?{generate_url_query(query_map)}"
+    else:
+        prev = None
+
+    if current_page < total_page_count:
+        query_map.update(dict(page=current_page + 1))
+        next_ = f"{base_url}?{generate_url_query(query_map)}"
+    else:
+        next_ = None
+
+    return PageLinks(
+        current=current,
+        prev=prev,
+        next=next_,
+    )

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -1,0 +1,5 @@
+from urllib.parse import urlencode
+
+
+def generate_url_query(query_map: dict) -> str:
+    return urlencode({k: v for k, v in query_map.items() if v is not None})

--- a/src/models.py
+++ b/src/models.py
@@ -95,6 +95,11 @@ class TransactionRead(TransactionBase):
     category: CategoryReadNested | None = None
 
 
+class TransactionPage(BaseModel):
+    data: list[TransactionRead]
+    total_count: int
+
+
 class DeleteResponse(BaseModel):
     detail: str
 

--- a/src/models.py
+++ b/src/models.py
@@ -1,9 +1,28 @@
 import re
 from datetime import date, datetime, timezone
 from decimal import Decimal
+from typing import Annotated
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from fastapi import Query
+from pydantic import BaseModel, ConfigDict, HttpUrl, field_validator
 from sqlmodel import Field, Relationship, SQLModel
+
+
+class PaginationInput(BaseModel):
+    page: int = Field(default=1, ge=1)
+    size: int = Field(default=25, ge=1, le=50)
+
+
+class TransactionQueryParams(BaseModel):
+    q: Annotated[str | None, Query(max_length=40)] = None
+    start_date: date | None = None
+    end_date: date | None = None
+
+
+class PageLinks(BaseModel):
+    current: HttpUrl
+    prev: HttpUrl | None = None
+    next: HttpUrl | None = None
 
 
 class MySQLModel(SQLModel):
@@ -98,12 +117,8 @@ class TransactionRead(TransactionBase):
 class TransactionPage(BaseModel):
     data: list[TransactionRead]
     total_count: int
+    links: PageLinks
 
 
 class DeleteResponse(BaseModel):
     detail: str
-
-
-class PaginationInput(BaseModel):
-    page: int = Field(default=1, ge=1)
-    size: int = Field(default=25, ge=1, le=50)

--- a/src/routers/transactions.py
+++ b/src/routers/transactions.py
@@ -1,5 +1,5 @@
 import re
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from typing import Annotated
 
 from fastapi import APIRouter, HTTPException, Query, status
@@ -43,6 +43,8 @@ def read_transactions(
     session: SessionDep,
     pagination_input: PaginationDep,
     q: Annotated[str | None, Query(max_length=40)] = None,
+    start_date: date | None = None,
+    end_date: date | None = None,
 ):
     query = select(Transaction)
 
@@ -60,7 +62,11 @@ def read_transactions(
         )
 
     # date range filter
-    # TODO
+    if start_date is not None:
+        query = query.where(Transaction.trans_date >= start_date)
+
+    if end_date is not None:
+        query = query.where(Transaction.trans_date <= end_date)
 
     # pagination
     offset = (pagination_input.page - 1) * pagination_input.size

--- a/tests/test_api_transactions.py
+++ b/tests/test_api_transactions.py
@@ -1,6 +1,8 @@
 import pytest
 from fastapi.testclient import TestClient
 
+from src.helpers import generate_url_query
+
 
 @pytest.fixture()
 def add_category(client: TestClient):
@@ -192,6 +194,25 @@ def test_get_transactions_search_by_term(
     client: TestClient, add_transaction, add_another_transaction, term, expected_count
 ):
     response = client.get(f"/transactions/?q={term}")
+    data = response.json()
+    assert response.status_code == 200
+    assert len(data) == expected_count
+
+
+@pytest.mark.parametrize(
+    "start_date,end_date,expected_count",
+    [("2024-01-01", "2024-12-31", 1), (None, "2024-12-31", 1), ("2025-01-01", None, 1)],
+)
+def test_get_transactions_search_by_date(
+    client: TestClient,
+    add_transaction,
+    add_another_transaction,
+    start_date,
+    end_date,
+    expected_count,
+):
+    url_query = generate_url_query({"start_date": start_date, "end_date": end_date})
+    response = client.get(f"/transactions/?{url_query}")
     data = response.json()
     assert response.status_code == 200
     assert len(data) == expected_count

--- a/tests/test_api_transactions.py
+++ b/tests/test_api_transactions.py
@@ -178,7 +178,7 @@ def test_create_or_update_transaction_422_bad_amount(
 
 def test_get_transactions(client: TestClient, add_transaction, add_another_transaction):
     response = client.get("/transactions")
-    data = response.json()
+    data = response.json()["data"]
 
     assert response.status_code == 200
     assert len(data) == 2
@@ -194,7 +194,7 @@ def test_get_transactions_search_by_term(
     client: TestClient, add_transaction, add_another_transaction, term, expected_count
 ):
     response = client.get(f"/transactions/?q={term}")
-    data = response.json()
+    data = response.json()["data"]
     assert response.status_code == 200
     assert len(data) == expected_count
 
@@ -213,7 +213,7 @@ def test_get_transactions_search_by_date(
 ):
     url_query = generate_url_query({"start_date": start_date, "end_date": end_date})
     response = client.get(f"/transactions/?{url_query}")
-    data = response.json()
+    data = response.json()["data"]
     assert response.status_code == 200
     assert len(data) == expected_count
 


### PR DESCRIPTION
## Change Log
- Enhance GET transaction route with search and pagination features
  - Add ability to filter transactions by start date and end date
  - Refactor returned transactions into a `data` object
  - Return total record count in `total_count` object
  - Return `links` object with URLs to navigate to the next and previous page

## TODO
- [ ] Build tests for row count and links returned in GET transactions route
- [ ] Refactor GET transactions route into smaller functions (It's way too long now)
- [ ] Set up Postgres database in Docker to replace current SQLite database
