### PR TITLE
Day 14 - Add Year-Month Validation, Adjust Visualization for Edge Cases

### DIFF
--- a/src/api/helpers.py
+++ b/src/api/helpers.py
@@ -135,6 +135,16 @@ def create_page(
     return page_output
 
 
+def validate_year_month(year_month: str) -> str:
+    year, month = map(int, year_month.split("-"))
+    if year > date.today().year:
+        raise ValueError("Input year cannot exceed current year.")
+    if not (1 <= month <= 12):
+        raise ValueError("Input month must be between '01' and '12'.")
+
+    return year_month
+
+
 def get_month_range(year_month: str) -> DateRange:
     """
     Parse month in `YYYY-MM` format.

--- a/src/api/routers/reports.py
+++ b/src/api/routers/reports.py
@@ -42,8 +42,8 @@ def get_monthly_report(year_month: YearMonthParam, session: SessionDep):
     # final query to get category info
     query = (
         select(
-            Category.id.label("category_id"),
-            Category.name.label("category_name"),
+            Category.id.label("category_id"),  # ty: ignore[unresolved-attribute]
+            Category.name.label("category_name"),  # ty: ignore[unresolved-attribute]
             func.coalesce(subq.c.amount_spent, 0).label("amount_spent"),
             Category.budget,
         )
@@ -51,7 +51,8 @@ def get_monthly_report(year_month: YearMonthParam, session: SessionDep):
             outerjoin(Category, subq, Category.id == subq.c.category_id, full=True)
         )
         .order_by(
-            case((Category.budget.is_(None), 1), else_=0), nulls_last(Category.name)
+            case((Category.budget.is_(None), 1), else_=0),  # ty: ignore[unresolved-attribute]
+            nulls_last(Category.name),
         )
     )
 

--- a/src/api/routers/transactions.py
+++ b/src/api/routers/transactions.py
@@ -60,9 +60,9 @@ def read_transactions(
         search_term = f"%{q}%"
         query = query.where(
             or_(
-                Transaction.vendor.ilike(search_term),
-                Transaction.note.ilike(search_term),
-                Transaction.category.has(Category.name.ilike(search_term)),
+                Transaction.vendor.ilike(search_term),  # ty: ignore[unresolved-attribute]
+                Transaction.note.ilike(search_term),  # ty: ignore[unresolved-attribute]
+                Transaction.category.has(Category.name.ilike(search_term)),  # ty: ignore[unresolved-attribute]
             )
         )
 
@@ -74,9 +74,9 @@ def read_transactions(
 
     # sort
     query = query.order_by(
-        Transaction.trans_date.desc(),
-        Transaction.vendor.desc(),
-        Transaction.amount.desc(),
+        Transaction.trans_date.desc(),  # ty: ignore[unresolved-attribute]
+        Transaction.vendor.desc(),  # ty: ignore[unresolved-attribute]
+        Transaction.amount.desc(),  # ty: ignore[unresolved-attribute]
     )
 
     page_output = create_page(query, query_map, pagination_input, session, request)

--- a/src/gui/pages/home.py
+++ b/src/gui/pages/home.py
@@ -14,13 +14,26 @@ def create() -> None:
             mint_green = "#78c2ad"
             mint_red = "#e25c5c"
 
-            def make_bullet(fig, title, value, budget, y_domain):
+            def make_bullet(
+                fig: go.Figure,
+                title: str,
+                value_str: str,
+                budget_str: str,
+                y_domain: list[float],
+            ):
+                value = currency_str_to_float(value_str)
+                budget = currency_str_to_float(budget_str)
                 is_under = value <= budget
-                delta_amount = round(abs(budget - value))
-                delta_text = f"${delta_amount:,} {'left' if is_under else 'over'}"
                 bar_color = mint_green if is_under else mint_red
 
-                value_text = f"${value:,} of ${budget:,}"
+                if budget_str is not None:
+                    delta_amount = round(abs(budget - value))
+                    delta_text = f"${delta_amount:,} {'left' if is_under else 'over'}"
+                else:
+                    delta_text = ""
+
+                if title is None:
+                    title = "No Category"
 
                 fig.add_trace(
                     go.Indicator(
@@ -34,19 +47,21 @@ def create() -> None:
                         gauge={
                             "shape": "bullet",
                             "axis": {
-                                "range": [None, max(value, budget)],
+                                "range": [
+                                    0.0,
+                                    max(value, budget, 1),
+                                ],  # max must be at least 1 for proper rendering
                                 "visible": False,
                             },
                             "bar": {"color": bar_color, "thickness": 1},
                         },
                         number={
                             "font": {
-                                "size": 20,
+                                "size": 16,
                             },
                             "prefix": "$",
                             "valueformat": ",.2f",
                         },
-                        customdata=[[value_text]],
                     )
                 )
 
@@ -71,8 +86,8 @@ def create() -> None:
                     make_bullet(
                         fig,
                         line["category_name"],
-                        value=currency_str_to_float(line["amount_spent"]),
-                        budget=currency_str_to_float(line["budget"]),
+                        value_str=line["amount_spent"],
+                        budget_str=line["budget"],
                         y_domain=[
                             (num_lines - i - 1) / num_lines + spacing,
                             (num_lines - i) / num_lines - spacing,

--- a/src/gui/pages/transactions.py
+++ b/src/gui/pages/transactions.py
@@ -126,14 +126,14 @@ def create() -> None:
                                 ).props("color=negative dense")
 
             def open_create_modal():
-                with ui.dialog() as dialog, ui.card().classes("w-[700px]"):
+                with ui.dialog() as dialog, ui.card().classes("w-[700px] items-center"):
                     ui.label("Add Transaction").classes("text-lg font-semibold")
 
-                    with ui.row().classes("gap-4"):
+                    with ui.row().classes("justify-between"):
                         # date selector
                         with ui.input(
                             "Date", value=datetime.date.today().isoformat()
-                        ) as date:
+                        ).classes("w-4/10") as date:
                             with ui.menu().props("no-parent-event") as menu:
                                 with ui.date().bind_value(date):
                                     with ui.row().classes("justify-end"):
@@ -145,17 +145,17 @@ def create() -> None:
                                     "cursor-pointer"
                                 )
 
-                        amount = ui.number("Amount").classes("w-full")
-                    with ui.row().classes("gap-4"):
-                        vendor = ui.input("Vendor").classes("w-full")
+                        amount = ui.number("Amount").classes("w-4/10")
+                    with ui.row().classes("justify-between"):
+                        vendor = ui.input("Vendor").classes("w-4/10")
                         # category drop-down selector
                         category_id = ui.select(
                             label="Category",
                             options=get_selectable_categories(),
                             with_input=True,
-                        ).classes("w-full")
+                        ).classes("w-4/10")
                     with ui.row():
-                        note = ui.textarea("Note").classes("w-full")
+                        note = ui.textarea("Note").classes("w-10/10")
 
                     with ui.row():
                         ui.button("Cancel", on_click=dialog.close)
@@ -183,12 +183,14 @@ def create() -> None:
                     ui.notify("Transaction created")
 
             def open_edit_modal(row):
-                with ui.dialog() as dialog, ui.card().classes("w-[700px]"):
+                with ui.dialog() as dialog, ui.card().classes("w-[700px] items-center"):
                     ui.label("Edit Transaction").classes("text-lg font-semibold")
 
-                    with ui.row().classes("gap-4"):
+                    with ui.row().classes("justify-between"):
                         # date selector
-                        with ui.input("Date", value=row["trans_date"]) as date:
+                        with ui.input("Date", value=row["trans_date"]).classes(
+                            "w-4/10"
+                        ) as date:
                             with ui.menu().props("no-parent-event") as menu:
                                 with ui.date().bind_value(date):
                                     with ui.row().classes("justify-end"):
@@ -202,10 +204,10 @@ def create() -> None:
 
                         amount = ui.number(
                             "Amount", value=currency_str_to_float(row["amount"])
-                        ).classes("w-full")
-                    with ui.row().classes("gap-4"):
+                        ).classes("w-4/10")
+                    with ui.row().classes("justify-between"):
                         vendor = ui.input("Vendor", value=row["vendor"]).classes(
-                            "w-full"
+                            "w-4/10"
                         )
                         # category drop-down selector
                         current_category_id = (
@@ -216,9 +218,9 @@ def create() -> None:
                             label="Category",
                             value=current_category_id,
                             with_input=True,
-                        ).classes("w-full")
+                        ).classes("w-4/10")
                     with ui.row():
-                        note = ui.textarea("Note", value=row["note"]).classes("w-full")
+                        note = ui.textarea("Note", value=row["note"]).classes("w-10/10")
 
                     with ui.row():
                         ui.button("Cancel", on_click=dialog.close)

--- a/tests/test_api_reports.py
+++ b/tests/test_api_reports.py
@@ -74,3 +74,22 @@ def test_get_monthly_report(client: TestClient, add_transactions):
     assert data[2]["category_name"] is None
     assert data[2]["amount_spent"] == "25.00"
     assert data[2]["budget"] is None
+
+
+@pytest.mark.parametrize(
+    "year_month,expected_error_type,expected_msg",
+    [
+        ("blah", "string_pattern_mismatch", "String should match pattern"),
+        ("9999-12", "value_error", "cannot exceed current year"),
+        ("2025-14", "value_error", "must be between '01' and '12'"),
+    ],
+)
+def test_get_month_report_422_bad_param(
+    client: TestClient, year_month, expected_error_type, expected_msg
+):
+    url = f"/reports/monthly_budget?year_month={year_month}"
+    response = client.request("GET", url)
+    data = response.json()
+    assert response.status_code == 422
+    assert data["detail"][0]["type"] == expected_error_type
+    assert expected_msg in data["detail"][0]["msg"]


### PR DESCRIPTION
## Change Log
- Add validation of `year_month` to API reports route. Used recommendation from [FastAPI docs](https://fastapi.tiangolo.com/tutorial/query-params-str-validations/#custom-validation).
- Add tests for `year_month` validation.
- Update data visualization for edge cases (eg category has no budget, etc)
- Suppress "unresolved attribute" error in `ty` for SQLModel related issues only.
- Improve layout of Transaction forms in NiceGUI.

## TODO 
- [ ] Begin dockerization of services (Postgres, FastAPI, NiceGUI)
- [ ] Write documentation for project